### PR TITLE
Bug Fix #13: Allow upload to HT if NO “Other Data file” was selected.

### DIFF
--- a/mainwindowimpl.py
+++ b/mainwindowimpl.py
@@ -564,7 +564,6 @@ class MainWindow(QMainWindow):
 
     def toggleButtons(self):
         if (self.ui.hyperthoughtTemplateLineEdit.text() != "" and
-            self.ui.otherDataFileLineEdit.text() != "" and
             self.ui.useTemplateListView.model().rowCount() > 0 and
                 self.ui.hyperThoughtUploadPath.text() != ""):
 


### PR DESCRIPTION
I.e. a pure custom template.
Solution: Got rid of the rule to look for the other data file line edit
to be empty

Updates #13 