### PR TITLE
Tell QSettings we expect a list

### DIFF
--- a/metaforge_preferences.py
+++ b/metaforge_preferences.py
@@ -46,7 +46,7 @@ class MetaForgePreferencesDialog(QDialog):
     
     def read_settings(self):
         settings = QSettings(QApplication.organizationName(), QApplication.applicationName())
-        parser_folder_paths: List[str] = settings.value(self.K_SETTINGS_PARSER_PATHS_KEY)
+        parser_folder_paths: List[str] = settings.value(self.K_SETTINGS_PARSER_PATHS_KEY, type=list)
 
         if parser_folder_paths is None:
             parser_folder_paths: List[str] = []


### PR DESCRIPTION
This was getting converted to a path for each character for me, in
general it helps QSettings when we specify the type we are expected.
This fixed local issues I saw without changing/fixing the settings
file.