### PR TITLE
Fix bug reported in some HDF5 files with strings

### DIFF
--- a/parsers/h5_parser.py
+++ b/parsers/h5_parser.py
@@ -35,7 +35,14 @@ class H5Parser(MetaForgeParser):
     Perform type dispatch and figure out whether to make an entry
     """
     if isinstance(value, bytes):
-      return value.decode('utf-8')
+      if len(value) > 0:
+        # Default to UTF-8 (most common encoding), fallback to "old-school"
+        try:
+          return value.decode('utf-8')
+        except:
+          return value.decode('ISO-8859-1')
+      else:
+        return ""
     elif isinstance(value, numpy.void):
       # These are some weirdly encoded numpy arrays!
       return None


### PR DESCRIPTION
Some HDF5 files caused an error when they had inline extended characters. Most modern implementations encode using UTF-8 but the previous default was ISO-8859-1 for many years. This is probably the most pragmatic approach to handling most strings.