### PR TITLE
Deleting Create Template table rows using the X now works properly

### DIFF
--- a/createtemplatewidget.py
+++ b/createtemplatewidget.py
@@ -206,7 +206,7 @@ class CreateTemplateWidget(QWidget):
             self.metadata_table_model.metadata_model.remove_by_index(source_index.row())
             self.metadata_table_model.endRemoveRows()
         elif entry is not None and entry.source_type is EzMetadataEntry.SourceType.FILE:
-            self.metadata_tree_model.changeLeafCheck(entry.source_path)
+            self.metadata_tree_model.changeLeafCheck(entry)
         
         self.metadata_table_model_proxy.invalidate()
         index0 = self.metadata_table_model.index(0, 0)


### PR DESCRIPTION
+ When a table row is chosen for deletion, we take its underlying EzMetadataEntry path and search the tree looking for that same EzMetadataEntry path.  Once we find a tree item with a matching EzMetadataEntry path, we uncheck that tree item which then fires off a signal that deletes the corresponding table row.  The issue was that when searching the tree for matching paths, we were not checking the entire tree...we were only checking the first item and its children.  I updated the code to check the entire tree recursively, and to also compare entire EzMetadataEntry objects instead of just the paths within the objects.