### PR TITLE
ENH: Ability to build up a template using multiple data files

### DIFF
--- a/metaforge/ez_models/ezmetadataentry.py
+++ b/metaforge/ez_models/ezmetadataentry.py
@@ -29,3 +29,4 @@ class EzMetadataEntry:
     editable: bool = True
     required: bool = False
     enabled: bool = True
+    loaded: bool = True

--- a/metaforge/ez_models/ezmetadatamodel.py
+++ b/metaforge/ez_models/ezmetadatamodel.py
@@ -178,26 +178,6 @@ class EzMetadataModel:
                 return i
         return -1
 
-    def to_file_tree_dict(self) -> dict:
-        tree_dict = {}
-
-        for entry in self.entries:
-            if entry.source_type is not EzMetadataEntry.SourceType.FILE:
-                continue
-
-            source_path = entry.source_path
-            source_tokens = source_path.split('/')
-            tree_obj = tree_dict
-            for i in range(len(source_tokens)):
-                token = source_tokens[i]
-                if token not in tree_obj:
-                    if i == len(source_tokens) - 1:
-                        tree_obj[token] = entry.source_value
-                    else:
-                        tree_obj[token] = {}
-                tree_obj = tree_obj[token]
-        return tree_dict
-
     def size(self) -> int:
         return len(self.entries)
 

--- a/metaforge/models/treemodel.py
+++ b/metaforge/models/treemodel.py
@@ -16,12 +16,12 @@ class TreeModel(QAbstractItemModel):
         super(TreeModel, self).__init__(parent)
 
         self.rootItem = TreeItem(display_name=header)
-        self.metadata_model = metadata_model
-        self.setupModelData(self.metadata_model)
+        self.setupModelData(metadata_model)
 
     def changeLeafCheck(self, entry: EzMetadataEntry):
         index = self._get_index_from_entry(entry)
-        self.setData(index, 0, Qt.CheckStateRole)
+        if index.isValid():
+            self.setData(index, 0, Qt.CheckStateRole)
 
     def columnCount(self, parent=QModelIndex()):
         return self.rootItem.columnCount()
@@ -204,15 +204,12 @@ class TreeModel(QAbstractItemModel):
 
         return result
 
-    def reload_model_data(self):
+    def clearModel(self):
         self.removeRows(0, self.rowCount())
-        self.setupModelData(self.metadata_model)
 
     def setupModelData(self, metadata_model: EzMetadataModel):
-        # treeDict = metadata_model.to_file_tree_dict()
-
         for entry in metadata_model.entries:
-            if entry.source_type is not EzMetadataEntry.SourceType.FILE:
+            if entry.source_type is not EzMetadataEntry.SourceType.FILE or entry.loaded is False:
                 continue
 
             source_path = entry.source_path

--- a/metaforge/models/treemodel.py
+++ b/metaforge/models/treemodel.py
@@ -17,7 +17,7 @@ class TreeModel(QAbstractItemModel):
 
         self.rootItem = TreeItem(display_name=header)
         self.metadata_model = metadata_model
-        self.setupModelData(self.metadata_model, self.rootItem)
+        self.setupModelData(self.metadata_model)
 
     def changeLeafCheck(self, entry: EzMetadataEntry):
         index = self._get_index_from_entry(entry)
@@ -204,7 +204,11 @@ class TreeModel(QAbstractItemModel):
 
         return result
 
-    def setupModelData(self, metadata_model: EzMetadataModel, parent):
+    def reload_model_data(self):
+        self.removeRows(0, self.rowCount())
+        self.setupModelData(self.metadata_model)
+
+    def setupModelData(self, metadata_model: EzMetadataModel):
         # treeDict = metadata_model.to_file_tree_dict()
 
         for entry in metadata_model.entries:

--- a/metaforge/qt_models/qcreateeztablemodel.py
+++ b/metaforge/qt_models/qcreateeztablemodel.py
@@ -1,8 +1,12 @@
 from PySide2.QtCore import QSortFilterProxyModel, Qt
+from PySide2.QtGui import QColor
 
 from metaforge.ez_models.ezmetadataentry import EzMetadataEntry
+from metaforge.qt_models.qeztablemodel import QEzTableModel
 
 class QCreateEzTableModel(QSortFilterProxyModel):
+    K_NOT_LOADED_BG_COLOR = QEzTableModel.K_YELLOW_BG_COLOR
+
     def __init__(self, data, parent=None):
         QSortFilterProxyModel.__init__(self, parent)
         self.setDynamicSortFilter(True)
@@ -11,10 +15,18 @@ class QCreateEzTableModel(QSortFilterProxyModel):
     def data(self, index, role):
         if not index.isValid():
             return None
+        
+        src_model = self.sourceModel()
+        if src_model is None:
+            return None
 
         if role == Qt.DisplayRole:
-            if index.column() == self.sourceModel().K_SORT_COL_INDEX:
+            if index.column() == src_model.K_SORT_COL_INDEX:
                 return index.row() + 1
+        if role == Qt.BackgroundRole:
+            src_index = self.mapToSource(index)
+            metadata_entry: EzMetadataEntry = src_model.metadata_model.entry(src_index.row())
+            return self._get_background_color_data(metadata_entry)
 
         return super().data(index, role)
 
@@ -37,3 +49,9 @@ class QCreateEzTableModel(QSortFilterProxyModel):
             return metadata_entry.enabled
         else:
             return False
+    
+    def _get_background_color_data(self, metadata_entry: EzMetadataEntry) -> QColor:
+        if metadata_entry.source_type is EzMetadataEntry.SourceType.FILE and metadata_entry.loaded is False:
+            return self.K_NOT_LOADED_BG_COLOR
+
+        return None

--- a/metaforge/qt_models/qeztablemodel.py
+++ b/metaforge/qt_models/qeztablemodel.py
@@ -1,5 +1,5 @@
 from PySide2.QtCore import QAbstractTableModel, Qt, QModelIndex
-from PySide2.QtGui import QFont
+from PySide2.QtGui import QFont, QColor
 
 from metaforge.ez_models.ezmetadataentry import EzMetadataEntry
 from metaforge.ez_models.ezmetadatamodel import EzMetadataModel
@@ -11,11 +11,16 @@ class QEzTableModel(QAbstractTableModel):
     in this section. This will make it easier to move columns around and rename items.
     """
 
+    # Row colors
+    K_RED_BG_COLOR = QColor(255, 190, 194)
+    K_YELLOW_BG_COLOR = QColor(253, 255, 190)
+
     # Total Number of Columns
     K_COL_COUNT = 10
 
     # These are some misc strings that are used.
     K_FROM_SOURCE = "--SOURCE--"
+    K_NOT_LOADED = "--NOT LOADED--"
     K_CUSTOM_VALUE = "--CUSTOM VALUE--"
 
     # These are the user facing header and the index of each column in the table.
@@ -73,10 +78,13 @@ class QEzTableModel(QAbstractTableModel):
             elif index.column() == self.K_HTNAME_COL_INDEX:
                 return metadata_entry.ht_name
             elif index.column() == self.K_SOURCEVAL_COL_INDEX:
-                if metadata_entry.source_type is EzMetadataEntry.SourceType.CUSTOM:
-                    return str(self.K_CUSTOM_VALUE)
+                if metadata_entry.source_type is EzMetadataEntry.SourceType.FILE:
+                    if metadata_entry.loaded is True:
+                        return str(metadata_entry.source_value)
+                    else:
+                        return self.K_NOT_LOADED
                 else:
-                    return str(metadata_entry.source_value)
+                    return str(self.K_CUSTOM_VALUE)
             elif index.column() == self.K_SOURCE_COL_INDEX:
                 if metadata_entry.source_type is EzMetadataEntry.SourceType.CUSTOM:
                     return self.K_CUSTOM_VALUE

--- a/metaforge/qt_models/quseeztablemodel.py
+++ b/metaforge/qt_models/quseeztablemodel.py
@@ -1,8 +1,9 @@
+from typing import List
+
 from PySide2.QtCore import QSortFilterProxyModel, Qt, QRegExp, QModelIndex
 from PySide2.QtGui import QColor, QIcon, QFont
 
-from typing import List
-
+from metaforge.qt_models.qeztablemodel import QEzTableModel
 from metaforge.ez_models.ezmetadataentry import EzMetadataEntry
 
 class QUseEzTableModel(QSortFilterProxyModel):
@@ -20,9 +21,9 @@ class QUseEzTableModel(QSortFilterProxyModel):
     K_FROMFILE_MSG = "Using data file value"
 
     # Row colors
-    K_MISSING_ENTRY_COLOR = QColor(255, 190, 194)
-    K_OVERRIDDEN_ENTRY_COLOR = QColor(253, 255, 190)
-    K_TEMPLATEFILE_ENTRY_COLOR = QColor(253, 255, 190)
+    K_MISSING_ENTRY_COLOR = QEzTableModel.K_RED_BG_COLOR
+    K_OVERRIDDEN_ENTRY_COLOR = QEzTableModel.K_YELLOW_BG_COLOR
+    K_TEMPLATEFILE_ENTRY_COLOR = QEzTableModel.K_YELLOW_BG_COLOR
 
     # These are the user facing header and the index of each column in the table.
     K_SOURCE_COL_NAME = "Source"

--- a/metaforge/qt_models/quseeztablemodel.py
+++ b/metaforge/qt_models/quseeztablemodel.py
@@ -184,7 +184,8 @@ class QUseEzTableModel(QSortFilterProxyModel):
                 self.dataChanged.emit(index, index)
                 return True
             elif index.column() == self.K_HTVALUE_COL_INDEX:
-                metadata_entry.override_source_value = (value != metadata_entry.source_value)
+                if metadata_entry.source_type == EzMetadataEntry.SourceType.FILE:
+                    metadata_entry.override_source_value = (value != metadata_entry.source_value)
                 metadata_entry.ht_value = value
                 self.dataChanged.emit(index, index)
                 return True

--- a/metaforge/qt_models/quseeztablemodel.py
+++ b/metaforge/qt_models/quseeztablemodel.py
@@ -19,6 +19,7 @@ class QUseEzTableModel(QSortFilterProxyModel):
     K_MISSING_MSG = "Missing from data file"
     K_FROMTEMPLATE_MSG = "Using value from template file"
     K_FROMFILE_MSG = "Using data file value"
+    K_CUSTOMENTRY_MSG = "Custom entry"
 
     # Row colors
     K_MISSING_ENTRY_COLOR = QEzTableModel.K_RED_BG_COLOR
@@ -142,7 +143,7 @@ class QUseEzTableModel(QSortFilterProxyModel):
                 return self.K_FROMTEMPLATE_MSG
             else:
                 return self.K_FROMFILE_MSG
-        return None
+        return self.K_CUSTOMENTRY_MSG
     
     def _get_background_color_data(self, metadata_entry: EzMetadataEntry) -> QColor:
         if metadata_entry.source_type is EzMetadataEntry.SourceType.FILE:
@@ -178,12 +179,12 @@ class QUseEzTableModel(QSortFilterProxyModel):
         metadata_entry: EzMetadataEntry = src_model.metadata_model.entry(src_index.row())
             
         if role == Qt.EditRole:
-
             if index.column() == self.K_HTNAME_COL_INDEX:
                 metadata_entry.ht_name = value
                 self.dataChanged.emit(index, index)
                 return True
             elif index.column() == self.K_HTVALUE_COL_INDEX:
+                metadata_entry.override_source_value = (value != metadata_entry.source_value)
                 metadata_entry.ht_value = value
                 self.dataChanged.emit(index, index)
                 return True
@@ -261,16 +262,8 @@ class QUseEzTableModel(QSortFilterProxyModel):
         return Qt.ItemIsEnabled | Qt.ItemIsSelectable
     
     def _get_htvalue_flags(self, metadata_entry: EzMetadataEntry) -> Qt.ItemFlags:
-        if metadata_entry.source_type is EzMetadataEntry.SourceType.FILE:
-            if metadata_entry.override_source_value is True:
-                if metadata_entry.editable is True:
-                    return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
-            elif self.metadata_file_chosen is True:
-                if metadata_entry.editable is True:
-                    return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
-        else:
-            if metadata_entry.editable is True:
-                return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
+        if metadata_entry.editable is True:
+            return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
         return Qt.ItemIsEnabled | Qt.ItemIsSelectable
 
     def _get_htannotation_flags(self, metadata_entry: EzMetadataEntry) -> Qt.ItemFlags:

--- a/metaforge/widgets/UI_Files/createtemplatewidget.ui
+++ b/metaforge/widgets/UI_Files/createtemplatewidget.ui
@@ -13,162 +13,69 @@
   <property name="windowTitle">
    <string>Create Template Widget</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
+  <layout class="QGridLayout" name="gridLayout" rowstretch="0,1,0">
    <property name="leftMargin">
-    <number>0</number>
+    <number>1</number>
    </property>
    <property name="topMargin">
-    <number>0</number>
+    <number>1</number>
    </property>
    <property name="rightMargin">
-    <number>0</number>
+    <number>1</number>
    </property>
    <property name="bottomMargin">
-    <number>0</number>
+    <number>1</number>
    </property>
-   <property name="verticalSpacing">
-    <number>-1</number>
-   </property>
-   <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="25,75">
-     <property name="leftMargin">
-      <number>8</number>
-     </property>
-     <property name="rightMargin">
-      <number>8</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QFrame" name="create_frame_2">
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Raised</enum>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_9">
-        <item row="0" column="0">
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="create_label_2">
-            <property name="text">
-             <string>Search Table</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="createTemplateTreeSearchBar">
-            <property name="placeholderText">
-             <string>Search metadata keys using wildcard (*.*)</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="0">
-         <widget class="QTreeView" name="metadataTreeView">
+   <item row="0" column="0">
+    <widget class="QWidget" name="dataFileParserWidget" native="true">
+     <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0">
+      <property name="leftMargin">
+       <number>1</number>
+      </property>
+      <property name="topMargin">
+       <number>1</number>
+      </property>
+      <property name="rightMargin">
+       <number>1</number>
+      </property>
+      <property name="bottomMargin">
+       <number>1</number>
+      </property>
+      <item row="3" column="0" colspan="3">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="fileParserLabel">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="toolTip">
-           <string>The metadata structure found inside the Data File.  Checked metadata entries are chosen to be included in the new template file and will appear in the table on the right.</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOn</enum>
-          </property>
-          <property name="alternatingRowColors">
-           <bool>true</bool>
+          <property name="text">
+           <string>Parser:</string>
           </property>
          </widget>
         </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QFrame" name="create_frame_1">
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Raised</enum>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_8">
-        <item row="2" column="0" colspan="3">
-         <widget class="QTableView" name="metadata_table_view">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>1</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
+        <item>
+         <widget class="QComboBox" name="fileParserCombo">
           <property name="toolTip">
-           <string>The metadata chosen to be included in the new template file.</string>
+           <string>The parser used to parse and extract the metadata from the data file above. </string>
           </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOn</enum>
+          <property name="currentText">
+           <string/>
           </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOn</enum>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QAbstractScrollArea::AdjustToContents</enum>
-          </property>
-          <property name="editTriggers">
-           <set>QAbstractItemView::AnyKeyPressed|QAbstractItemView::DoubleClicked</set>
-          </property>
-          <property name="showDropIndicator" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="dragDropOverwriteMode">
-           <bool>false</bool>
-          </property>
-          <property name="alternatingRowColors">
-           <bool>true</bool>
-          </property>
-          <property name="selectionBehavior">
-           <enum>QAbstractItemView::SelectRows</enum>
-          </property>
-          <property name="showGrid">
-           <bool>false</bool>
-          </property>
-          <property name="sortingEnabled">
-           <bool>true</bool>
-          </property>
-          <property name="cornerButtonEnabled">
-           <bool>false</bool>
-          </property>
-          <attribute name="horizontalHeaderStretchLastSection">
-           <bool>true</bool>
-          </attribute>
-          <attribute name="verticalHeaderVisible">
-           <bool>false</bool>
-          </attribute>
-          <attribute name="verticalHeaderMinimumSectionSize">
-           <number>15</number>
-          </attribute>
          </widget>
         </item>
-        <item row="3" column="0">
-         <spacer name="horizontalSpacer_8">
+        <item>
+         <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Expanding</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -178,202 +85,265 @@
           </property>
          </spacer>
         </item>
-        <item row="3" column="2">
-         <widget class="QPushButton" name="removeCreateTableRowButton">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Remove a custom value from the template</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="icon">
-           <iconset resource="../../../resources.qrc">
-            <normaloff>:/resources/Images/delete@2x.png</normaloff>:/resources/Images/delete@2x.png</iconset>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QPushButton" name="appendCreateTableRowButton">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Add a custom value to the template</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="icon">
-           <iconset resource="../../../resources.qrc">
-            <normaloff>:/resources/Images/plus@2x.png</normaloff>:/resources/Images/plus@2x.png</iconset>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0" colspan="3">
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="create_label_1">
-            <property name="text">
-             <string>Search Table</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="createTemplateListSearchBar">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>1</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="placeholderText">
-             <string>Search table using wildcard (*.*)</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
        </layout>
-      </widget>
-     </item>
-    </layout>
+      </item>
+      <item row="0" column="0" rowspan="2">
+       <widget class="QLabel" name="data_file_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Data File(s):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2" rowspan="2">
+       <widget class="QPushButton" name="dataFileSelect">
+        <property name="toolTip">
+         <string>Select data file to use for metadata extraction</string>
+        </property>
+        <property name="text">
+         <string>Select</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" rowspan="2">
+       <widget class="QLineEdit" name="dataFileLineEdit">
+        <property name="toolTip">
+         <string>This data file will be used as the model to create the template file.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+        <property name="placeholderText">
+         <string>Drag a file here or select one using the 'Select' button to the right===&gt;</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item row="1" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <property name="leftMargin">
-      <number>8</number>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="topMargin">
-      <number>8</number>
-     </property>
-     <property name="rightMargin">
-      <number>8</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <property name="spacing">
-        <number>9</number>
+     <widget class="QWidget" name="create_widget_2" native="true">
+      <layout class="QGridLayout" name="gridLayout_9">
+       <property name="leftMargin">
+        <number>1</number>
        </property>
-       <item>
-        <widget class="QLabel" name="data_file_label">
+       <property name="topMargin">
+        <number>1</number>
+       </property>
+       <property name="rightMargin">
+        <number>1</number>
+       </property>
+       <property name="bottomMargin">
+        <number>1</number>
+       </property>
+       <item row="0" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="create_label_2">
+           <property name="text">
+            <string>Search Table</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="createTemplateTreeSearchBar">
+           <property name="placeholderText">
+            <string>Search metadata keys using wildcard (*.*)</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="0">
+        <widget class="QTreeView" name="metadataTreeView">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="text">
-          <string>Data File</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="dataFileLineEdit">
          <property name="toolTip">
-          <string>This data file will be used as the model to create the template file.</string>
+          <string>The metadata structure found inside the Data File.  Checked metadata entries are chosen to be included in the new template file and will appear in the table on the right.</string>
          </property>
-         <property name="text">
-          <string/>
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOn</enum>
          </property>
-         <property name="readOnly">
+         <property name="alternatingRowColors">
           <bool>true</bool>
          </property>
-         <property name="placeholderText">
-          <string>Drag a file here or select one using the 'Select' button to the right===&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="dataFileSelect">
-         <property name="toolTip">
-          <string>Select data file to use for metadata extraction</string>
-         </property>
-         <property name="text">
-          <string>Select</string>
-         </property>
         </widget>
        </item>
       </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <property name="spacing">
-        <number>6</number>
+     </widget>
+     <widget class="QWidget" name="create_widget_1" native="true">
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>0</height>
+       </size>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_8">
+       <property name="leftMargin">
+        <number>1</number>
        </property>
-       <item>
-        <widget class="QLabel" name="fileParserLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+       <property name="topMargin">
+        <number>1</number>
+       </property>
+       <property name="rightMargin">
+        <number>1</number>
+       </property>
+       <property name="bottomMargin">
+        <number>1</number>
+       </property>
+       <item row="1" column="3">
+        <widget class="QPushButton" name="appendCreateTableRowButton">
+         <property name="minimumSize">
+          <size>
+           <width>40</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>40</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Add a custom value to the template</string>
          </property>
          <property name="text">
-          <string>File Parser</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="fileParserCombo">
-         <property name="toolTip">
-          <string>The parser used to parse and extract the metadata from the data file above. </string>
-         </property>
-         <property name="currentText">
           <string/>
          </property>
         </widget>
        </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+       <item row="1" column="0" colspan="3">
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="bottomMargin">
+          <number>0</number>
          </property>
-         <property name="sizeHint" stdset="0">
+         <item>
+          <widget class="QLabel" name="create_label_1">
+           <property name="text">
+            <string>Search Table</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="createTemplateListSearchBar">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="placeholderText">
+            <string>Search table using wildcard (*.*)</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="4">
+        <widget class="QPushButton" name="removeCreateTableRowButton">
+         <property name="minimumSize">
           <size>
            <width>40</width>
-           <height>20</height>
+           <height>0</height>
           </size>
          </property>
-        </spacer>
+         <property name="maximumSize">
+          <size>
+           <width>40</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Remove a custom value from the template</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" rowspan="3" colspan="5">
+        <widget class="QTableView" name="metadata_table_view">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The metadata chosen to be included in the new template file.</string>
+         </property>
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOn</enum>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOn</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContents</enum>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::AnyKeyPressed|QAbstractItemView::DoubleClicked</set>
+         </property>
+         <property name="showDropIndicator" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="dragDropOverwriteMode">
+          <bool>false</bool>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+         <property name="showGrid">
+          <bool>false</bool>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <property name="cornerButtonEnabled">
+          <bool>false</bool>
+         </property>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="verticalHeaderMinimumSectionSize">
+          <number>15</number>
+         </attribute>
+        </widget>
        </item>
       </layout>
-     </item>
-    </layout>
+     </widget>
+    </widget>
    </item>
-   <item row="3" column="0">
+   <item row="2" column="0">
     <layout class="QGridLayout" name="gridLayout_4">
      <property name="leftMargin">
       <number>8</number>
@@ -387,6 +357,16 @@
      <property name="bottomMargin">
       <number>4</number>
      </property>
+     <item row="0" column="0">
+      <widget class="QPushButton" name="clearCreateButton">
+       <property name="toolTip">
+        <string>Reset all 'Create Template' input fields. All fields will be reset to an empty state.</string>
+       </property>
+       <property name="text">
+        <string>Reset All Fields</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="2">
       <widget class="QPushButton" name="saveTemplateButton">
        <property name="toolTip">
@@ -415,16 +395,6 @@
         </size>
        </property>
       </spacer>
-     </item>
-     <item row="0" column="0">
-      <widget class="QPushButton" name="clearCreateButton">
-       <property name="toolTip">
-        <string>Reset all 'Create Template' input fields. All fields will be reset to an empty state.</string>
-       </property>
-       <property name="text">
-        <string>Reset All Fields</string>
-       </property>
-      </widget>
      </item>
      <item row="1" column="0" colspan="3">
       <widget class="QLabel" name="error_label">

--- a/metaforge/widgets/createtemplatewidget.py
+++ b/metaforge/widgets/createtemplatewidget.py
@@ -278,9 +278,17 @@ class CreateTemplateWidget(QWidget):
                 new_entry = metadata_model.entry_by_source(entry.source_path)
                 if new_entry is None:
                     # Exists in current model but not in incoming model
-                    # Make the entry custom because it's no longer part of the current file model
-                    entry.source_type = EzMetadataEntry.SourceType.CUSTOM
-                    entry.enabled = True
+                    if entry.enabled:
+                        # Make the entry custom because it's no longer part of the current file model
+                        entry.source_type = EzMetadataEntry.SourceType.CUSTOM
+                        
+                        # The overridden value is already stored in ht_value
+                        # IF the entry does not have an overridden value, use the source value as ht_value
+                        if not entry.override_source_value:
+                            entry.ht_value = entry.source_value
+                    else:
+                        # This entry is disabled, so it should not be included as a custom value
+                        self.metadata_model.remove(entry)
                 else:
                     # Exists in both the current model and the incoming model
                     # Keep all settings the same for this entry, just replace the source value

--- a/metaforge/widgets/createtemplatewidget.py
+++ b/metaforge/widgets/createtemplatewidget.py
@@ -264,13 +264,13 @@ class CreateTemplateWidget(QWidget):
         # Create an EzMetadataModel from the metadata dictionary
         metadata_model = EzMetadataModel.create_model_from_dict(model_dict=headerDict, source_type=EzMetadataEntry.SourceType.FILE)
 
-        # Reload tree view
-        self.metadata_tree_model.clearModel()
-        self.metadata_tree_model.setupModelData(metadata_model)
-        self.ui.metadataTreeView.expandAll()
-
         # Merge the new EzMetadataModel with the existing EzMetadataModel
         self._merge_metadata_model(metadata_model=metadata_model)
+
+        # Reload tree view
+        self.metadata_tree_model.clearModel()
+        self.metadata_tree_model.setupModelData(self.metadata_model)
+        self.ui.metadataTreeView.expandAll()
 
         # Reload table view
         self.filter_metadata_table()

--- a/metaforge/widgets/usetemplatewidget.py
+++ b/metaforge/widgets/usetemplatewidget.py
@@ -219,27 +219,28 @@ class UseTemplateWidget(QWidget):
         proxy_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
         proxy_model.setFilterWildcard(f'*{filter_text}*')
 
-    def remove_model_entry(self, source_row = -1):
-        if source_row != -1:
-            entry = self.use_ez_table_model.metadata_model.entry(source_row)
-            if entry is not None and entry.source_type is EzMetadataEntry.SourceType.CUSTOM:
-                self.use_ez_table_model.beginRemoveRows(QModelIndex(), source_row, source_row)
-                self.use_ez_table_model.metadata_model.remove_by_index(source_row)
+    def remove_model_entry(self, source_index = QModelIndex()):
+        if source_index.isValid():
+            entry = self.use_ez_table_model.metadata_model.entry(source_index.row())
+            if entry is not None:
+                # if entry.source_type is EzMetadataEntry.SourceType.FILE and entry.loaded is True:
+                #     entry.enabled = False
+                # else:
+                self.use_ez_table_model.beginRemoveRows(QModelIndex(), source_index.row(), source_index.row())
+                self.use_ez_table_model.metadata_model.remove_by_index(source_index.row())
                 self.use_ez_table_model.endRemoveRows()
-            elif entry is not None and entry.source_type is EzMetadataEntry.SourceType.FILE:
-                entry.enabled = False
         else:
             proxy_selected_rows = reversed(self.ui.useTemplateTableView.selectionModel().selectedRows())
-            source_row = -1
             for index in proxy_selected_rows:
                 source_row = (index.model().mapToSource(index)).row()
                 entry = self.use_ez_table_model.metadata_model.entry(source_row)
-                if entry is not None and entry.source_type is EzMetadataEntry.SourceType.CUSTOM:
+                if entry is not None:
+                    # if entry.source_type is EzMetadataEntry.SourceType.FILE and entry.loaded is True:
+                    #     entry.enabled = False
+                    # else:
                     self.use_ez_table_model.beginRemoveRows(QModelIndex(), source_row, source_row)
                     self.use_ez_table_model.metadata_model.remove_by_index(source_row)
                     self.use_ez_table_model.endRemoveRows()
-                elif entry is not None and entry.source_type is EzMetadataEntry.SourceType.FILE:
-                    entry.enabled = False
         
         self.use_ez_table_model_proxy.invalidate()
         index0 = self.use_ez_table_model_proxy.index(0, 0)


### PR DESCRIPTION
+ Users can build up their template metadata table by loading additional data files.  The application intelligently figures out which file metadata entries to keep active and which ones to deactivate based on the latest incoming file metadata.

+ Rewrote the checkbox delegate to properly paint centered checkboxes on top of the row background color.

+ File entries that are edited in the Use Template side before the data file is loaded do not reload when the data file is loaded.