### PR TITLE
Standardize parsers returning flattened dictionaries

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - Pillow>=8.2.0
     - python-dateutil
     - h5py
+    - flatten-dict==0.4.2
     - hyperthought
 
 about:

--- a/environment.yml
+++ b/environment.yml
@@ -12,4 +12,5 @@ dependencies:
   - python-dateutil
   - pyyaml
   - h5py
+  - flatten-dict=0.4.2
   - hyperthought

--- a/metaforge/ez_models/ezmetadatamodel.py
+++ b/metaforge/ez_models/ezmetadatamodel.py
@@ -80,26 +80,18 @@ class EzMetadataModel:
     def create_model_from_dict(model_dict: dict, source_type: EzMetadataEntry.SourceType) -> EzMetadataModel:
         model = EzMetadataModel()
         if model_dict is not None:
-            model.add_model_entry(item=model_dict, parent_path='', source_type=source_type)
-        return model
-
-    def add_model_entry(self, item, parent_path: str, source_type: EzMetadataEntry.SourceType):
-        for key, value in item.items():
-            if type(value) is dict:
-                new_parent_path = parent_path + key + '/'
-                self.add_model_entry(item=value, parent_path=new_parent_path, source_type=source_type)
-            else:
-                item_path = parent_path + key
+            for key, value in model_dict.items():
                 if value is None:
                     value = ''
-                metadata_entry = EzMetadataEntry(source_path=item_path,
-                                                 source_value=value,
-                                                 source_type=source_type,
-                                                 ht_name=key,
-                                                 ht_value=value,
-                                                 ht_annotation='',
-                                                 ht_units='')
-                self.entries.append(metadata_entry)
+                metadata_entry = EzMetadataEntry(source_path=key,
+                                                    source_value=value,
+                                                    source_type=source_type,
+                                                    ht_name=key,
+                                                    ht_value=value,
+                                                    ht_annotation='',
+                                                    ht_units='')
+                model.entries.append(metadata_entry)
+        return model
 
     def update_model_values_from_dict(self, item: dict, parent_path: str = "") -> List[EzMetadataEntry]:
         visited = [False for _ in range (self.size())]

--- a/metaforge/parsers/ang_parser.py
+++ b/metaforge/parsers/ang_parser.py
@@ -210,9 +210,9 @@ class AngParser(MetaForgeParser):
           value = None
           if len(tokens) > 1:
             value = ANG_HEADER_PARSE_MAP[keyword](' '.join(tokens[1:]))
-          ang_header.entries[keyword] = value
+          ang_header.entries[f'SOURCE/{keyword}'] = value
         else:
-          ang_header.unknown_entries[keyword] = ' '.join(tokens[1:])
+          ang_header.unknown_entries[f'SOURCE/{keyword}'] = ' '.join(tokens[1:])
     return ang_header
 
   def parse_header_as_dict(self, filepath: Path) -> dict:
@@ -220,27 +220,14 @@ class AngParser(MetaForgeParser):
     entries = header.entries
     phases = header.phases
 
-    phases_dict = self._get_phases_as_dict(phases)
-    entries["Phases"] = phases_dict
-    file_name = "SOURCE"
-    file_dict = {file_name: entries}
-
-    return file_dict
-
-  def _get_phases_as_dict(self, phases: Dict[int, AngPhase]) -> dict:
-    phases_dict: dict = {}
     for x in phases:
       phase = phases[x]
+      entries[f'SOURCE/Phases/Phase {x}/MaterialName'] = phase.material_name
+      entries[f'SOURCE/Phases/Phase {x}/Formula'] = phase.formula
+      entries[f'SOURCE/Phases/Phase {x}/Symmetry'] = phase.symmetry
+      entries[f'SOURCE/Phases/Phase {x}/PointGroupID'] = phase.point_group_id
+      entries[f'SOURCE/Phases/Phase {x}/LatticeConstants (ABC)'] = [phase.lattice_constants[0], phase.lattice_constants[1], phase.lattice_constants[2]]
+      entries[f'SOURCE/Phases/Phase {x}/LatticeConstants (Alpha, Beta, Gamma)'] = [phase.lattice_constants[3], phase.lattice_constants[4], phase.lattice_constants[5]]
+      entries[f'SOURCE/Phases/Phase {x}/NumberFamilies'] = len(phase.hkl_families)
 
-      phase_dict: dict = {}
-      phase_dict['MaterialName'] = phase.material_name
-      phase_dict['Formula'] = phase.formula
-      phase_dict['Symmetry'] = phase.symmetry
-      phase_dict['PointGroupID'] = phase.point_group_id
-      phase_dict['LatticeConstants (ABC)'] = [phase.lattice_constants[0], phase.lattice_constants[1], phase.lattice_constants[2]]
-      phase_dict['LatticeConstants (Alpha, Beta, Gamma)'] = [phase.lattice_constants[3], phase.lattice_constants[4], phase.lattice_constants[5]]
-      phase_dict['NumberFamilies'] = len(phase.hkl_families)
-
-      phases_dict[f"Phase {x}"] = phase_dict
-
-    return phases_dict
+    return entries

--- a/metaforge/parsers/fei_tiff_parser.py
+++ b/metaforge/parsers/fei_tiff_parser.py
@@ -4,6 +4,7 @@ from requests.api import head
 from typing import List
 from pathlib import Path
 from uuid import UUID
+from flatten_dict import flatten
 
 from metaforge.parsers.metaforgeparser import MetaForgeParser
 
@@ -178,15 +179,18 @@ class FeiTiffParser(MetaForgeParser):
 
     header = self.parse_tiff_tag_34681(filepath)
     if len(header) > 0:
-      file_dict["FEI Tag #34681"] = header
+      flattened_header = flatten(header, reducer="path")
+      file_dict["FEI Tag #34681"] = flattened_header
 
     header = self.parse_tiff_tag_34682(filepath)
     if len(header) > 0:
-      file_dict["FEI Tag #34682"] = header
+      flattened_header = flatten(header, reducer="path")
+      file_dict["FEI Tag #34682"] = flattened_header
 
     header = self.parse_tiff_tag_50431(filepath)
     if len(header) > 0:
-      file_dict["FEI Tag #50431"] = header
+      flattened_header = flatten(header, reducer="path")
+      file_dict["FEI Tag #50431"] = flattened_header
 
     header = self.parse_standard_tags(filepath)
     if len(header) > 0:

--- a/metaforge/parsers/fei_tiff_parser.py
+++ b/metaforge/parsers/fei_tiff_parser.py
@@ -179,21 +179,22 @@ class FeiTiffParser(MetaForgeParser):
 
     header = self.parse_tiff_tag_34681(filepath)
     if len(header) > 0:
-      flattened_header = flatten(header, reducer="path")
-      file_dict["FEI Tag #34681"] = flattened_header
+      file_dict["FEI Tag #34681"] = header
+      file_dict = flatten(file_dict, reducer="path")
 
     header = self.parse_tiff_tag_34682(filepath)
     if len(header) > 0:
-      flattened_header = flatten(header, reducer="path")
-      file_dict["FEI Tag #34682"] = flattened_header
+      file_dict["FEI Tag #34682"] = header
+      file_dict = flatten(file_dict, reducer="path")
 
     header = self.parse_tiff_tag_50431(filepath)
     if len(header) > 0:
-      flattened_header = flatten(header, reducer="path")
-      file_dict["FEI Tag #50431"] = flattened_header
+      file_dict["FEI Tag #50431"] = header
+      file_dict = flatten(file_dict, reducer="path")
 
     header = self.parse_standard_tags(filepath)
     if len(header) > 0:
       file_dict["Standard"] = header
+      file_dict = flatten(file_dict, reducer="path")
 
     return file_dict

--- a/metaforge/parsers/ini_parser.py
+++ b/metaforge/parsers/ini_parser.py
@@ -2,6 +2,7 @@ import configparser
 from typing import List
 from pathlib import Path
 from uuid import UUID
+from flatten_dict import flatten
 
 from metaforge.parsers.metaforgeparser import MetaForgeParser
 
@@ -64,6 +65,7 @@ class IniParser(MetaForgeParser):
         pass
     finally:
       file_dict = {"SOURCE": header}
+      file_dict = flatten(file_dict, reducer="path")
 
     return file_dict
 


### PR DESCRIPTION
+ Updated ANG, CTF, FEI TIFF, and INI parsers so that they return flattened dictionaries.
+ All the other parsers already return flattened dictionaries.
+ Removed the nested dictionary logic from EzMetadataModel.